### PR TITLE
Revert "Cleanup/Refactor + expose classname prop"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build": "tsdx build",
     "test": "tsdx test --env=jsdom --passWithNoTests",
     "lint": "tsdx lint",
-    "lint:fix": "yarn lint --fix",
     "prepare": "tsdx build"
   },
   "peerDependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,37 +1,33 @@
-import React, { memo } from 'react';
+import * as React from 'react';
 
 type Props = {
-  children: React.ReactNode;
-  className?: string;
-};
+  children: React.ReactNode
+}
 
-function ReactHeightAutoTransition({ children, className }: Props) {
-  const ref = React.useRef<HTMLDivElement | null>(null);
+function Component({ children }: Props) {
+
+  const ref = React.useRef<HTMLDivElement | null>(null)
 
   React.useEffect(() => {
-    const { current: el } = ref;
-
-    if (!el || !el.firstChild) {
-      return;
+    const { current: el } = ref
+    if (el && el.firstChild) {
+      const firstChild = el.firstChild as HTMLDivElement
+      el.style.height = firstChild.scrollHeight + 'px'
     }
-
-    const firstChild = el.firstChild as HTMLDivElement;
-
-    el.style.height = firstChild.scrollHeight + 'px';
-  });
+  })
 
   return (
-    <div className={className} ref={ref} style={style}>
-      {children}
+    <div ref={ref} style={style}>
+      <div>{children}</div>
     </div>
-  );
+  )
 }
 
 const style: React.CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   overflow: 'hidden',
-  transition: 'height 300ms ease',
-};
+  transition: 'height 300ms ease'
+}
 
-export default memo(ReactHeightAutoTransition);
+export const ReactHeightAutoTransition = React.memo(Component)

--- a/test/blah.test.tsx
+++ b/test/blah.test.tsx
@@ -6,12 +6,9 @@ describe('it', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div');
     //
-    ReactDOM.render(
-      <ReactHeightAutoTransition>
-        <div>test</div>
-      </ReactHeightAutoTransition>,
-      div
-    );
+    ReactDOM.render(<ReactHeightAutoTransition>
+      <div>test</div>
+    </ReactHeightAutoTransition>, div);
     ReactDOM.unmountComponentAtNode(div);
   });
 });


### PR DESCRIPTION
Reverts trevorwhealy/react-height-auto-transition#3

Code changes seemed fine, although ideally, we pass all props, not just `className`

On closer look, it seems that the export was actually modified which broke the demos because it changed the way the component is imported at callsites to a default.